### PR TITLE
github: build binary from the local source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       run: go install go.k6.io/xk6/cmd/xk6@latest
 
     - name: Build the binary
-      run: xk6 build --with github.com/grafana/xk6-distributed-tracing@latest
+      run: xk6 build --with github.com/grafana/xk6-distributed-tracing=.
       
     - name: Upload binaries to release
       uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
This will circumvent goproxy which likely will not return us a *just*
pushed tag